### PR TITLE
Zia create new pac version

### DIFF
--- a/zscaler/zia/pac_files.py
+++ b/zscaler/zia/pac_files.py
@@ -415,71 +415,71 @@ class PacFilesAPI:
         """
         return self.rest.delete(f"pacFiles/{pac_id}").status_code
 
- def create_new_pac_version(
-            self,
-            pac_id: str,
-            pac_version: str,
-            pac_commit_message: str,
-            pac_verification_status: str,
-            pac_version_status: str,
-            pac_content: str,
-            **kwargs,
-        ) -> Box:
-            """
-            Performs to create a new PAC Version from an already deployed PAC. 
-
-            Args:
-                pac_id (str): The unique identifier of the PAC file to be updated.
-                pac_version (str): The specific version of the PAC file to be updated.
-                pac_commit_message (str): Commit message for the PAC file.
-                pac_verification_status (str): Verification status of the PAC file.
-                                            Supported Values: `VERIFY_NOERR`, `VERIFY_ERR`, `NOVERIFY`
-                pac_version_status (str): Version status of the PAC file.
-                                        Supported Values: `DEPLOYED`, `STAGE`, `LKG`
-                pac_content (str): The actual PAC file content to be updated.
-
-
-            Keyword Args:
-                Additional optional parameters as key-value pairs.
-
-            Returns:
-                Box: The updated PAC file resource record.
-
-
-            Example:
-                >>> pac_file = zia.update_pac_file(
-                        pac_id="12345",
-                        pac_version="2",
-                        pac_commit_message="This change is done via SDK",
-                        pac_verification_status="VERIFY_NOERR",
-                        pac_version_status="DEPLOYED",
-                        pac_content="This needs to be your PAC
-                        )
-            """
-            # Step 1: Validate the PAC content
-            validation_result = self.validate_pac_file(pac_content)
-            if not validation_result.success:
-                raise Exception("PAC content validation failed: {}".format(validation_result))
-
-            # Step 2: Construct the URL with mandatory parameters and optional newLKGVer
-            url = f"/pacFiles/{pac_id}/version/{pac_version}"
-
-            # Step 3: Construct the payload with required fields
-            payload = {
-                "pacCommitMessage": pac_commit_message,
-                "pacVerificationStatus": pac_verification_status,
-                "pacVersionStatus": pac_version_status,
-                "pacContent": pac_content,
-            }
-
-            # Add any additional optional parameters
-            for key, value in kwargs.items():
-                payload[snake_to_camel(key)] = value
-
-            # Step 4: Make the request to update the PAC file
-            response = self.rest.post(url, json=payload)
-            if isinstance(response, Response):
-                if response.status_code != 200:
-                    raise Exception(f"API call failed with status {response.status_code}: {response.json()}")
-                return Box(response.json())
-            return response
+     def create_new_pac_version(
+                self,
+                pac_id: str,
+                pac_version: str,
+                pac_commit_message: str,
+                pac_verification_status: str,
+                pac_version_status: str,
+                pac_content: str,
+                **kwargs,
+            ) -> Box:
+                """
+                Performs to create a new PAC Version from an already deployed PAC. 
+    
+                Args:
+                    pac_id (str): The unique identifier of the PAC file to be updated.
+                    pac_version (str): The specific version of the PAC file to be updated.
+                    pac_commit_message (str): Commit message for the PAC file.
+                    pac_verification_status (str): Verification status of the PAC file.
+                                                Supported Values: `VERIFY_NOERR`, `VERIFY_ERR`, `NOVERIFY`
+                    pac_version_status (str): Version status of the PAC file.
+                                            Supported Values: `DEPLOYED`, `STAGE`, `LKG`
+                    pac_content (str): The actual PAC file content to be updated.
+    
+    
+                Keyword Args:
+                    Additional optional parameters as key-value pairs.
+    
+                Returns:
+                    Box: The updated PAC file resource record.
+    
+    
+                Example:
+                    >>> pac_file = zia.update_pac_file(
+                            pac_id="12345",
+                            pac_version="2",
+                            pac_commit_message="This change is done via SDK",
+                            pac_verification_status="VERIFY_NOERR",
+                            pac_version_status="DEPLOYED",
+                            pac_content="This needs to be your PAC
+                            )
+                """
+                # Step 1: Validate the PAC content
+                validation_result = self.validate_pac_file(pac_content)
+                if not validation_result.success:
+                    raise Exception("PAC content validation failed: {}".format(validation_result))
+    
+                # Step 2: Construct the URL with mandatory parameters and optional newLKGVer
+                url = f"/pacFiles/{pac_id}/version/{pac_version}"
+    
+                # Step 3: Construct the payload with required fields
+                payload = {
+                    "pacCommitMessage": pac_commit_message,
+                    "pacVerificationStatus": pac_verification_status,
+                    "pacVersionStatus": pac_version_status,
+                    "pacContent": pac_content,
+                }
+    
+                # Add any additional optional parameters
+                for key, value in kwargs.items():
+                    payload[snake_to_camel(key)] = value
+    
+                # Step 4: Make the request to update the PAC file
+                response = self.rest.post(url, json=payload)
+                if isinstance(response, Response):
+                    if response.status_code != 200:
+                        raise Exception(f"API call failed with status {response.status_code}: {response.json()}")
+                    return Box(response.json())
+                return response


### PR DESCRIPTION
This code can generate a new PAC Version eq. like an update. In the UI it is mentioned as "Create new Branch".

## Description

I added a new method to the "pac_files" class which can generate a new PAC Version. This will make it possible to do the Change via CLI instead of going to the UI and edit the PAC in the UI and create a new Branch etc.

Additionally it gives the customer the possibilities to push the change to different PAC Files without editing each one in the UI.
If he has test policies like initial, extended and productive he could do a change in the PAC Content and push it via CLI to the UI and test it. 

Also it would be possible to push the change directly to initial and extended tests for a bigger testing group.

closes #238

## Has your change been tested?

I tested the code already in the Zscalerbeta cloud and pushed some changes to the Cloud:
![image](https://github.com/user-attachments/assets/300ac27f-647a-4e68-89e2-c57c1a207222)

I was adding a comment via CLI:
// This is a Test via Zscaler SDK number | Now with verify PAC
and requested the User input for Commit:
commit_message = input("Enter the commit message: ")

In the UI I'm able to see the Commit Message and the Comment:
![image](https://github.com/user-attachments/assets/aaf4e886-6325-4575-852b-d5f0c9c87b5a)


But you can test the method by your own too.

I tested the code with our Zscalerbeta cloud and configured a PAC File locally with some changes in the Code and pushed it with this steps:
Reading the File as paccontent
request user Input for Commit
request user Input for PAC file to deploy the paccontent
validate PAC via method
activate change

After this I took the PAC URL and downloaded the file once and checked the file I created and the downloaded one.

There is no impact to the current deployed code since this is a new method in the pac_file class.

## Types of changes
Modify

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] This change is using publicly documented and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
