### PR TITLE
Adding cloud_apps.py to legacy.py and fixing errors found in CloudAppsAPI.list_apps()

### DIFF
--- a/zscaler/zia/cloud_apps.py
+++ b/zscaler/zia/cloud_apps.py
@@ -66,9 +66,12 @@ class CloudAppsAPI(APIClient):
         """
         )
 
+        query_params = query_params or {}
+
+        body = {}
         headers = {}
 
-        request, error = self._request_executor.create_request(http_method, api_url, {}, headers, {}, params=query_params)
+        request, error = self._request_executor.create_request(http_method, api_url, body, headers, params=query_params)
 
         if error:
             return (None, None, error)

--- a/zscaler/zia/legacy.py
+++ b/zscaler/zia/legacy.py
@@ -412,6 +412,16 @@ class LegacyZIAClientHelper:
         from zscaler.zia.cloud_applications import CloudApplicationsAPI
 
         return CloudApplicationsAPI(self.request_executor)
+    
+    @property
+    def cloud_apps(self):
+        """
+        The interface object for the :ref:`ZIA Cloud App Control <zia-cloud_apps>`.
+
+        """
+        from zscaler.zia.cloud_apps import CloudAppsAPI
+
+        return CloudAppsAPI(self.request_executor)
 
     @property
     def cloud_browser_isolation(self):


### PR DESCRIPTION
## Description

While using legacy.py to interact with our zscaler api I found that cloud_apps.py could not be called. I added that functionality and while testing ran into errors running CloudAppsAPI.list_apps() on line 71:

`request, error = self._request_executor.create_request(http_method, api_url, {}, headers, {}, params=query_params)`

Too many "params" were defined and I noticed this line of code did not match up with the other files making the same calls. I replaced this section of code to match and successfully executed my script with the changes in place.


## Has your change been tested?

Below is the portion of a quick script I used to test:

```
zia_env = LegacyZIAClientHelper(
    cloud=ZIA_CLOUD,
    username=ZIA_USERNAME,
    password=ZIA_PASSWORD,
    api_key=ZIA_API_KEY
)

apps, _, error = zia_env.cloud_apps.list_apps()
if error:
    print(f"Error listing cloud application instances: {error}")

with open("dir/cloud_apps.txt", "x") as file:
    for app in apps:
        application = app.name + " : " + str(app.id) + "\n"
        file.writelines(application)
```


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] This change is using publicly documented and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
