### PR TITLE
fix: Fixed incorrect required paramaters in add_url_category

### DIFF
--- a/zscaler/zia/url_categories.py
+++ b/zscaler/zia/url_categories.py
@@ -222,8 +222,8 @@ class URLCategoriesAPI(APIClient):
 
         if not super_category:
             raise ValueError("`super_category` is required.")
-        if not urls:
-            raise ValueError("`urls` cannot be empty.")
+        if not urls and not kwargs.get("db_categorized_urls", []):
+            raise ValueError("`urls` and `db_categorized_urls` cannot be both empty.")
 
         custom_category = kwargs.pop("custom_category", False)
 


### PR DESCRIPTION
Fix incorrect validation on required paramaters in `add_url_category`

Fixes #284 

## Description

Zscaler's API does not require `urls` to not be empty if `db_categorized_urls` is not empty.

## Has your change been tested?

Validated on a production instance of zscaler, and I was previously using an older version of this library that didn't enforce this parameter and it worked, the newer version of the SDK in fact broke my system, given that I'm creating url categories for which `urls` is empty.

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] This change is using publicly documented and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
