### PR TITLE
Safely Handle if Logging is Disabled

### DIFF
--- a/zscaler/logger.py
+++ b/zscaler/logger.py
@@ -24,7 +24,9 @@ def setup_logging(logger_name="zscaler-sdk-python", enabled=None, verbose=None):
 
     if not enabled:
         # If logging is not enabled, set up a null handler
-        logging.disable(logging.INFO)
+        # NOTE: we do not want to disable logging completely.
+        # This allows the logger to be used but does not output anything for the 'zscaler-sdk-python' logger.
+        logging.getLogger(logger_name).addHandler(logging.NullHandler())
         return
 
     if verbose is None:

--- a/zscaler/zpa/microtenants.py
+++ b/zscaler/zpa/microtenants.py
@@ -21,7 +21,6 @@ from zscaler.zpa.models.microtenants import MicrotenantSearch
 from zscaler.utils import format_url
 import logging
 
-logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION

## Description
- fixes https://github.com/zscaler/zscaler-sdk-python/issues/269
- When using the SDK in our own Python application;
  - our logging gets hidden. This is because of:
   ```
   logging.disable(logging.INFO)
   ```
  - our logger format gets overridden. This is because of:
   ```
   logging.basicConfig(level=logging.DEBUG)
   ```

## Has your change been tested?

Yes. Using the below code snippet (thanks to @Tonyynot14) we followed this test case:

1. Using the SDK without any code changes, run the snippet.
2. Confirm we see NO logs.
3. Now make the changes that are in this PR and run the snippet again
4. We see the log:
   ```
    Confirming we see this log
   ```

### Code Snippet

```python
from zscaler.oneapi_client import LegacyZIAClient
import logging

LOG = logging.getLogger(__name__)
LOG.setLevel(logging.INFO)
LOG.addHandler(logging.StreamHandler())


def main():
    LOG.info("Confirming we see this log")


if __name__ == "__main__":
    main()
```


## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/348adcc3-8c10-4e99-b1d4-d1d9033bda91)


## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] This change is using publicly documented and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
