### PR TITLE
[RFQ] Add maxRetrySeconds configuration parameter and RetryTooLong exception

### DIFF
--- a/zscaler/__init__.py
+++ b/zscaler/__init__.py
@@ -33,3 +33,4 @@ __version__ = "1.4.4"
 
 
 from zscaler.oneapi_client import Client as ZscalerClient  # noqa
+from zscaler.exceptions.exceptions import RetryTooLong  # noqa

--- a/zscaler/config/config_setter.py
+++ b/zscaler/config/config_setter.py
@@ -39,6 +39,7 @@ class ConfigSetter:
             "proxy": {"port": "", "host": "", "username": "", "password": ""},
             "rateLimit": {
                 "maxRetries": 2,
+                "maxRetrySeconds": 0,
             },
             "testing": {"disableHttpsCheck": ""},
         }
@@ -136,7 +137,7 @@ class ConfigSetter:
 
         self._config["client"]["userAgent"] = ""
         self._config["client"]["requestTimeout"] = 0
-        self._config["client"]["rateLimit"] = {"maxRetries": 2}
+        self._config["client"]["rateLimit"] = {"maxRetries": 2, "maxRetrySeconds": 0}
 
         # Add a check for the 'testing' key before accessing it
         if "testing" not in self._config:

--- a/zscaler/exceptions/exceptions.py
+++ b/zscaler/exceptions/exceptions.py
@@ -84,3 +84,10 @@ class TokenRefreshError(Exception):
 
 class HeaderUpdateError(Exception):
     pass
+
+
+class RetryTooLong(Exception):
+    def __init__(self, retry_seconds, max_seconds):
+        self.retry_seconds = retry_seconds
+        self.max_seconds = max_seconds
+        super().__init__(f"Retry time of {retry_seconds} seconds exceeds maximum allowed {max_seconds} seconds")

--- a/zscaler/request_executor.py
+++ b/zscaler/request_executor.py
@@ -73,6 +73,11 @@ class RequestExecutor:
         if self._max_retries < 0:
             raise ValueError(f"Invalid max retries: {self._max_retries}. Must be 0 or greater.")
 
+        # Validate and set max retry seconds for rate limiting
+        self._max_retry_seconds = config["client"]["rateLimit"].get("maxRetrySeconds", 0)
+        if self._max_retry_seconds < 0:
+            raise ValueError(f"Invalid max retry seconds: {self._max_retry_seconds}. Must be 0 or greater.")
+
         # Set configuration and cache
         self._config = config
         self._cache = cache
@@ -499,6 +504,12 @@ class RequestExecutor:
             backoff_seconds = self.get_retry_after(response.headers, logger)
             if backoff_seconds is None:
                 return None, response, response.text, Exception(ERROR_MESSAGE_429_MISSING_DATE_X_RESET)
+
+            # Check if backoff exceeds max retry seconds limit
+            if self._max_retry_seconds > 0 and backoff_seconds > self._max_retry_seconds:
+                from zscaler.exceptions.exceptions import RetryTooLong
+                logger.warning(f"Retry time of {backoff_seconds} seconds exceeds maximum allowed {self._max_retry_seconds} seconds")
+                return request, response, response.text, RetryTooLong(backoff_seconds, self._max_retry_seconds)
 
             logger.info(f"Hit rate limit or retryable status {response.status_code}. "
                         f"Retrying request in {backoff_seconds} seconds.")


### PR DESCRIPTION
# Add maxRetrySeconds Configuration and RetryTooLong Exception

## Summary
This PR implements the feature request from ticket **SZ-1** to add a maximum retry time limit for requests. When the required retry wait time exceeds the configured maximum, the SDK will throw a `RetryTooLong` exception instead of waiting.

## Changes Made

### 1. Configuration Enhancement
- Added `maxRetrySeconds` parameter to the `client.rateLimit` configuration section
- Default value is `0` (meaning unlimited retry time)
- Added validation to ensure the value is 0 or greater

### 2. New Exception Class
- Created `RetryTooLong` exception in `zscaler/exceptions/exceptions.py`
- Includes `retry_seconds` and `max_seconds` properties
- Provides descriptive error message with both values

### 3. Request Executor Updates
- Added validation for `maxRetrySeconds` parameter in constructor
- Modified retry logic in `fire_request_helper` method to check backoff time against limit
- Logs warning message before throwing exception
- Only performs check when `_max_retry_seconds > 0`

### 4. Module Exports
- Exported `RetryTooLong` exception in `zscaler/__init__.py` for easy access

## Usage Example
```python
from zscaler import ZscalerClient, RetryTooLong

with ZscalerClient(
    config={
        "client": {
            "rateLimit": {
                "maxRetrySeconds": 50
            }
        }
    }
) as client:
    try:
        results = client.zcc.devices.list_device()
    except RetryTooLong:
        print("Retry time is too long.")
```

## Implementation Details
- The check applies to all retryable status codes (408, 409, 412, 429, 500, 502, 503, 504)
- When `maxRetrySeconds` is 0, retry behavior is unlimited (existing behavior preserved)
- When `maxRetrySeconds` > 0, any retry requiring more than this time will throw `RetryTooLong`
- Follows existing code patterns for validation and exception handling

## Testing
- Verified configuration parsing works correctly
- Tested exception creation and properties
- Confirmed RequestExecutor validation logic
- Ensured existing retry behavior is preserved when `maxRetrySeconds = 0`

## Files Modified
- `zscaler/config/config_setter.py` - Added maxRetrySeconds to default config
- `zscaler/exceptions/exceptions.py` - Added RetryTooLong exception class
- `zscaler/request_executor.py` - Added validation and retry time checking logic
- `zscaler/__init__.py` - Exported new exception

---

**Jira Ticket:** SZ-1  
**Link to Devin run:** https://app.devin.ai/sessions/29ea93174be342dea167136b362332c1  
**Requested by:** Samir Chaudhry (samir@cognition.ai)
