### PR TITLE
Minor docstring update for zpa.add_access_rule() 

### DIFF
--- a/zscaler/zpa/policies.py
+++ b/zscaler/zpa/policies.py
@@ -561,7 +561,7 @@ class PolicySetControllerAPI(APIClient):
                     [('app', 'id', '99999'),
                     ('app', 'id', '88888'),
                     ('app_group', 'id', '77777),
-                    ('client_type', 'zpn_client_type_exporter', 'zpn_client_type_zapp'),
+                    ('client_type', 'id', 'zpn_client_type_zapp'),
                     ('trusted_network', 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxx', True)]
             custom_msg (str):
                 A custom message.


### PR DESCRIPTION
## Description

Not a code change, just a really small docstring update for this method. I've been migrating an integration written in go to python at work and go tripped up a bit on this leading to a few 400's while testing. 

The docstring specifically calls out (object, lhs, rhs) but I kept missing that so hoping this helps out anyone else breezing through the docs 😅 

